### PR TITLE
fix: consolidate hyphenation to prevent unwanted mid-word breaks, shorten TeamSpeak button label

### DIFF
--- a/src/app/components/main/home/sections/features-join/home-features-join.component.html
+++ b/src/app/components/main/home/sections/features-join/home-features-join.component.html
@@ -4,7 +4,7 @@
             title="Deine MilSim-Community für motivierte Einsteiger und taktische Profis"
             subtitle="Von Waffenkunde über Funken bis zu Taktik, Missionsbau und TvT. Wir bieten MilSim, das Spaß macht."
             containerClass="ttt-text-center mb-10"
-            titleClass="ttt-section-title mb-4"
+            titleClass="ttt-section-title hyphens-none mb-4"
             subtitleClass="ttt-description-text max-w-4xl"
             [showDivider]="true"
         ></ttt-section-header>

--- a/src/app/components/sidebar/right-sidebar/right-sidebar.component.html
+++ b/src/app/components/sidebar/right-sidebar/right-sidebar.component.html
@@ -25,7 +25,7 @@
                     title="TTT TeamSpeak Server"
                 ></iframe>
                 <div class="p-4 text-center">
-                    <a [href]="teamspeakUrl" class="ttt-btn-primary">TeamSpeak beitreten</a>
+                    <a [href]="teamspeakUrl" class="ttt-btn-primary">TS3 beitreten</a>
                 </div>
             </div>
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -47,6 +47,10 @@
 }
 
 @layer base {
+    body {
+        @apply hyphens-auto;
+    }
+
     h1,
     h2,
     h3,
@@ -78,9 +82,8 @@
         @apply border-tttWhite/30 bg-tttWhite/10 text-tttWhite hover:bg-tttWhite/20 rounded-xl border p-6 transition-colors duration-200;
     }
 
-    /* Heading scale, largest first. Margins belong in the layout, not here. */
     .ttt-hero-title {
-        @apply text-tttWhite text-3xl font-bold text-balance break-words hyphens-auto drop-shadow-lg md:text-4xl lg:text-5xl;
+        @apply text-tttWhite text-3xl font-bold break-words drop-shadow-lg md:text-4xl lg:text-5xl;
     }
 
     /* clone: keeps padding intact when the accent wraps */
@@ -89,39 +92,39 @@
     }
 
     .ttt-section-title {
-        @apply text-tttWhite text-3xl font-bold text-balance break-words hyphens-auto md:text-4xl;
+        @apply text-tttWhite text-3xl font-bold break-words md:text-4xl;
     }
 
     .ttt-section-badge {
-        @apply bg-tttRed text-tttWhite w-fit max-w-full px-3 py-1.5 text-xl font-bold text-balance break-words hyphens-auto;
+        @apply bg-tttRed text-tttWhite w-fit max-w-full px-3 py-1.5 text-xl font-bold break-words;
     }
 
     .ttt-subsection-title {
-        @apply text-tttWhite text-2xl font-bold text-balance break-words hyphens-auto;
+        @apply text-tttWhite text-2xl font-bold break-words;
     }
 
     .ttt-card-title {
-        @apply text-tttWhite text-lg font-bold text-balance break-words hyphens-auto;
+        @apply text-tttWhite text-lg font-bold break-words;
     }
 
     .ttt-label {
-        @apply text-tttWhite text-base font-semibold break-words hyphens-auto;
+        @apply text-tttWhite text-base font-semibold break-words;
     }
 
     .ttt-hero-text {
-        @apply text-tttGray-100 mx-auto mb-6 max-w-2xl text-base leading-relaxed text-pretty break-words hyphens-auto drop-shadow-md md:text-lg;
+        @apply text-tttGray-100 mx-auto mb-6 max-w-2xl text-base leading-relaxed text-pretty break-words drop-shadow-md md:text-lg;
     }
 
     .ttt-content-text {
-        @apply text-tttGray-200 space-y-4 leading-relaxed text-pretty break-words hyphens-auto;
+        @apply text-tttGray-200 space-y-4 leading-relaxed text-pretty break-words;
     }
 
     .ttt-description-text {
-        @apply text-tttGray-200 mx-auto max-w-3xl text-base leading-relaxed text-pretty break-words hyphens-auto md:text-lg;
+        @apply text-tttGray-200 mx-auto max-w-3xl text-base leading-relaxed text-pretty break-words md:text-lg;
     }
 
     .ttt-feature-description {
-        @apply text-tttGray-200 text-base leading-relaxed text-pretty break-words hyphens-auto;
+        @apply text-tttGray-200 text-base leading-relaxed text-pretty break-words;
     }
 
     .ttt-accent-text {


### PR DESCRIPTION
fix das mit Firefox usw mit der Schrift, bzw verbessert es. Habs in FF, Safari und Vivaldi getestet, soweit sah alles gut aus

Dazu noch TeamSpeak zu TS3 beim Viewer geändert, sodass es auf eine Zeile passt